### PR TITLE
upgrade target framework

### DIFF
--- a/src/NServiceBus.SagaAudit.AcceptanceTests/NServiceBus.SagaAudit.AcceptanceTests.csproj
+++ b/src/NServiceBus.SagaAudit.AcceptanceTests/NServiceBus.SagaAudit.AcceptanceTests.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
-    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
   <ItemGroup>
@@ -10,11 +9,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus.AcceptanceTesting" Version="8.0.0-alpha.631" />
-    <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="NUnit" Version="3.13.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NServiceBus.AcceptanceTesting" Version="8.0.0-alpha.631" />
+    <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/NServiceBus.SagaAudit.Tests/NServiceBus.SagaAudit.Tests.csproj
+++ b/src/NServiceBus.SagaAudit.Tests/NServiceBus.SagaAudit.Tests.csproj
@@ -4,7 +4,6 @@
     <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(SolutionDir)NServiceBus.snk</AssemblyOriginatorKeyFile>
-    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
   <ItemGroup>
@@ -12,11 +11,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="8.0.0-alpha.631" />
-    <PackageReference Include="Particular.Approvals" Version="0.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="NUnit" Version="3.13.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NServiceBus" Version="8.0.0-alpha.631" />
+    <PackageReference Include="Particular.Approvals" Version="0.2.0" />
     <PackageReference Include="PublicApiGenerator" Version="10.2.0" />
   </ItemGroup>
 

--- a/src/NServiceBus.SagaAudit.Tests/SagaEntitySerialization.cs
+++ b/src/NServiceBus.SagaAudit.Tests/SagaEntitySerialization.cs
@@ -1,8 +1,6 @@
-﻿#if NET452
-namespace NServiceBus.SagaAudit.Tests
+﻿namespace NServiceBus.SagaAudit.Tests
 {
     using System;
-    using System.Runtime.CompilerServices;
     using NUnit.Framework;
     using Particular.Approvals;
     using ServiceInsight.Saga;
@@ -12,7 +10,6 @@ namespace NServiceBus.SagaAudit.Tests
     public class SagaEntitySerialization
     {
         [Test]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public void Saga_entity_serializes_correctly()
         {
             var entity = new SagaEntity
@@ -75,6 +72,8 @@ namespace NServiceBus.SagaAudit.Tests
                     case "NestedObjectProperty":
                         value = p.Value.Replace(Environment.NewLine, string.Empty).Replace(" ", string.Empty).Replace(",NServiceBus", ", NServiceBus");
                         break;
+                    default:
+                        break;
                 }
 
                 Assert.AreEqual(expected, value, p.Key);
@@ -102,7 +101,9 @@ namespace NServiceBus.SagaAudit.Tests
             public TimeSpan? NullableTimeProperty { get; set; }
             public NestedObject NestedObjectProperty { get; set; }
             public static string StaticProperty { get; set; } = "test";
+#pragma warning disable IDE0051 // Remove unused private members
             string PrivateProperty { get; set; } = "test";
+#pragma warning restore IDE0051 // Remove unused private members
         }
     }
 }
@@ -125,5 +126,3 @@ namespace ServiceInsight.Saga
         public static IList<KeyValuePair<string, string>> ProcessArray(string stateAfterChange) => ProcessValues(stateAfterChange.TrimStart('[').TrimEnd(']'));
     }
 }
-
-#endif

--- a/src/NServiceBus.SagaAudit/NServiceBus.SagaAudit.csproj
+++ b/src/NServiceBus.SagaAudit/NServiceBus.SagaAudit.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net472;netcoreapp2.1</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(SolutionDir)NServiceBus.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/src/NServiceBus.SagaAudit/NServiceBus.SagaAudit.csproj
+++ b/src/NServiceBus.SagaAudit/NServiceBus.SagaAudit.csproj
@@ -10,11 +10,11 @@
     <Description>Allows auditing of saga state changes in NServiceBus endpoints</Description>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Label="Public dependencies">
     <PackageReference Include="NServiceBus" Version="[8.0.0-alpha.631, 9.0.0)" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Label="Private dependencies">
     <PackageReference Include="Particular.Packaging" Version="0.9.0" PrivateAssets="All" />
   </ItemGroup>
 


### PR DESCRIPTION
Target framework update to netcoreapp2.1 as part of https://github.com/Particular/Exploration/issues/482

There is 1 test excluded for net452, https://github.com/Particular/NServiceBus.SagaAudit/commit/10908e8c9aadaed22bd6798388c95b4de815d3ef#diff-7b61e07bf6e1419169b3f42d4d0dbb7603e4add2bf4e92eb50087d9551e4e945R1, I've asked the original committers what the intend was. 

**Update** the net452 target is matching the approval testing framework target, https://github.com/Particular/Particular.Approvals/blob/master/src/Tests/Tests.csproj which is also still net452. 